### PR TITLE
Bump gen_smtp dependency version to 0.14.0

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -24,7 +24,7 @@ defmodule Mailman.Mixfile do
   defp deps do
     [
       {:eiconv, "~> 1.0.0"},
-      {:gen_smtp, "~> 0.13.0"},
+      {:gen_smtp, "~> 0.14.0"},
       {:ex_doc, ">= 0.19.1", only: :dev},
       {:httpotion, "~> 3.1.0"},
       {:credo, "~> 0.10", only: [:dev, :test], runtime: false}

--- a/mix.lock
+++ b/mix.lock
@@ -4,7 +4,7 @@
   "earmark": {:hex, :earmark, "1.3.0", "17f0c38eaafb4800f746b457313af4b2442a8c2405b49c645768680f900be603", [:mix], [], "hexpm"},
   "eiconv": {:hex, :eiconv, "1.0.0", "ee1e47ee37799a05beff7a68d61f63cccc93101833c4fb94b454c23b12a21629", [:rebar3], []},
   "ex_doc": {:hex, :ex_doc, "0.19.1", "519bb9c19526ca51d326c060cb1778d4a9056b190086a8c6c115828eaccea6cf", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.7", [hex: :makeup_elixir, repo: "hexpm", optional: false]}], "hexpm"},
-  "gen_smtp": {:hex, :gen_smtp, "0.13.0", "11f08504c4bdd831dc520b8f84a1dce5ce624474a797394e7aafd3c29f5dcd25", [:rebar3], []},
+  "gen_smtp": {:hex, :gen_smtp, "0.14.0", "39846a03522456077c6429b4badfd1d55e5e7d0fdfb65e935b7c5e38549d9202", [:rebar3], [], "hexpm"},
   "httpotion": {:hex, :httpotion, "3.1.0", "14d20d9b0ce4e86e253eb91e4af79e469ad949f57a5d23c0a51b2f86559f6589", [:mix], [{:ibrowse, "~> 4.4", [hex: :ibrowse, optional: false]}]},
   "ibrowse": {:hex, :ibrowse, "4.4.0", "2d923325efe0d2cb09b9c6a047b2835a5eda69d8a47ed6ff8bc03628b764e991", [:rebar3], []},
   "jason": {:hex, :jason, "1.1.1", "d3ccb840dfb06f2f90a6d335b536dd074db748b3e7f5b11ab61d239506585eb2", [:mix], [{:decimal, "~> 1.0", [hex: :decimal, optional: true]}]},


### PR DESCRIPTION
This commit updates the gen_smtp dependency to pickup some compatibility
fixes for Erlant/OPT-22, notably:

```
** (UndefinedFunctionError) function :socket.connect/5 is undefined or private
    (gen_smtp) :socket.connect(:tcp, '0.0.0.0', 2525, [:binary, {:packet, :line}, {:keepalive, true}, {:active, false}], 5000)
    (gen_smtp) /Users/jonlunsford/work/epoxi/deps/gen_smtp/src/gen_smtp_client.erl:602: :gen_smtp_client.connect/2
    (gen_smtp) /Users/jonlunsford/work/epoxi/deps/gen_smtp/src/gen_smtp_client.erl:255: :gen_smtp_client.open_smtp_session/2
    (gen_smtp) /Users/jonlunsford/work/epoxi/deps/gen_smtp/src/gen_smtp_client.erl:200: :gen_smtp_client.try_smtp_sessions/3
    (gen_smtp) /Users/jonlunsford/work/epoxi/deps/gen_smtp/src/gen_smtp_client.erl:189: :gen_smtp_client.send_it/2
    (mailman) lib/mailman/external_smtp_adapter.ex:17: Mailman.ExternalSmtpAdapter.deliver/3
```
Closes [#85](https://github.com/mailman-elixir/mailman/issues/8)